### PR TITLE
[WIP]マイページの本人情報の追加登録ページ

### DIFF
--- a/app/assets/stylesheets/user_profile_information.scss
+++ b/app/assets/stylesheets/user_profile_information.scss
@@ -1,0 +1,128 @@
+//メルカリ＜マイページ＜本人情報の登録のscss
+
+.chapter-container {
+  background-color: #fff;
+  &__head {
+    @include font14_u3;
+    border-bottom: 1px solid #f5f5f5;
+    text-align: center;
+    padding: 8px 24px;
+  }
+  &__form {
+    padding: 64px;
+    border-top: 1px solid #f5f5f5;
+    &__titles {
+      @include font14__weight400;
+      &__title1 {
+        margin: 8px 0 0;
+      }
+    } 
+    &__right {
+      text-align: right;
+      color: #0099e8;
+      margin: 8px 0 0; 
+      font-size: 14px;
+      cursor: pointer;
+    }
+    &__right:hover{
+      text-decoration: underline;
+      opacity: 0.7;
+    }
+    &__group {
+      margin: 40px 0 0;
+      text-align: left;
+      font-size: 14px;
+      &__question {
+        font-weight: 600;
+        line-height: 14px;
+        display:inline-block;
+        vertical-align: middle;
+      }
+      &__any {
+        display: inline;
+        vertical-align: middle;
+        background-color: #ccc;
+        margin: 0 0 0 8px;
+        padding: 2px 4px;
+        font-size: 12px;
+        border-radius: 2px;
+        color: #fff;
+        vertical-align: top;
+      }
+      &__wrap {
+        margin: 8px 0 0;
+        position: relative;
+        &__select {
+          width: 100%;
+          height: 48px;
+          padding: 0 16px;
+          border-radius: 4px;
+          border: 1px solid #ccc;
+          font-size: 16px;
+          cursor: pointer;
+          -webkit-appearance: none;
+          -moz-appearance: none;
+          appearance: none;
+          background-color: #fff;
+        }
+        &__select:focus {
+          border: 1px solid #0299e8; 
+          z-index: 10;
+          outline: 0;
+        }
+        &__icon {
+          position: absolute;
+          right: 16px;
+          top: 35%;
+          z-index: 2;
+          color: #888;
+          font-size: 20px;
+        }
+      }
+      &__register {
+        margin: 8px 0 0;
+        line-height: 21px;
+      }
+      &__answer {
+        @include font16_u3;
+        width: 100%;
+        margin: 8px 0 0;
+        height: 48px;
+        padding: 10px 16px 8px;
+        border-radius: 4px;
+        border: 1px solid #ccc;
+        background-color: #fff;
+        box-sizing: border-box;
+      }
+      &__answer:focus {
+        border: 1px solid #0299e8; 
+        z-index: 10;
+        outline: 0;
+      }
+    }
+    &__button {
+      margin: 40px 0 0 0;
+      background: #ea352d;
+      color: #fff;
+      width: 100%;
+      line-height: 48px;
+      font-size: 14px;
+      text-align: center;
+      cursor: pointer;
+    }
+    &__button:focus {
+      outline: 0;
+    }
+    &__rights {
+      text-align: right;
+      color: #0099e8;
+      margin: 40px 0 0; 
+      font-size: 14px;
+      cursor: pointer;
+    }
+    &__rights:hover{
+      text-decoration: underline;
+      opacity: 0.7;
+    }
+  }
+}

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,3 +1,6 @@
 class Address < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  
+  belongs_to_active_hash :prefecture
   belongs_to :user, optional: true
 end

--- a/app/views/products/user_profile_information.html.haml
+++ b/app/views/products/user_profile_information.html.haml
@@ -1,0 +1,90 @@
+= render 'header'  # 全体のヘッダーの部分テンプレートの呼び出し
+.u-main
+  = render 'user_header'  # ユーザマイページのヘッダー部分テンプレートの呼び出し
+  .u-container
+    .container-center
+      = render 'user_sidebar'  # ユーザマイページのヘッダーの部分テンプレートの呼び出し
+      .contents
+        -# メルカリ＜マイページ＜本人情報の登録のhaml
+        .chapter-container
+          .chapter-container__head
+            本人情報の登録
+          .chapter-container__form
+            .chapter-container__form__titles
+              .chapter-container__form__titles__title1
+                お客さまの本人情報をご登録ください。
+              .chapter-container__form__titles__title2
+                登録されたお名前・生年月日を変更する場合、本人確認書類の提出が必要になります。
+            .chapter-container__form__right
+              本人確認書類のアップロードについて
+              = icon 'fas', 'angle-right'
+              = link_to ""
+            .chapter-container__form__group
+              .chapter-container__form__group__question
+                お名前
+              .chapter-container__form__group__register
+                日本 太郎
+            .chapter-container__form__group
+              .chapter-container__form__group__question
+                お名前カナ
+              .chapter-container__form__group__register
+                ニホン タロウ
+            .chapter-container__form__group
+              .chapter-container__form__group__question
+                生年月日
+              .chapter-container__form__group__register
+                1999/12/30
+            .chapter-container__form__group
+              .chapter-container__form__group__question
+                郵便番号
+              .chapter-container__form__group__any
+                任意
+              %input{type: "text", placeholder: "例)1234567", class: "chapter-container__form__group__answer"}
+
+
+            .chapter-container__form__group
+              .chapter-container__form__group__question
+                都道府県
+              .chapter-container__form__group__any
+                任意
+              = form_with model: @product, class: "chapter-container__form__group__wrap", local: true do |f|
+                = icon 'fa', 'chevron-down', class: "chapter-container__form__group__wrap__icon"
+                = f.collection_select :prefecture_id, Prefecture.all, :id, :name,{}, {class: "chapter-container__form__group__wrap__select"}
+                
+
+
+
+
+
+
+            .chapter-container__form__group
+              .chapter-container__form__group__question
+                市区町村  
+              .chapter-container__form__group__any
+                任意
+              %input{type: "text", placeholder: "例) 横浜市緑区", class: "chapter-container__form__group__answer"}
+            .chapter-container__form__group
+              .chapter-container__form__group__question
+                番地  
+              .chapter-container__form__group__any
+                任意
+              %input{type: "text", placeholder: "例) 青山1−1−1", class: "chapter-container__form__group__answer"}
+            .chapter-container__form__group
+              .chapter-container__form__group__question
+                建物名  
+              .chapter-container__form__group__any
+                任意
+              %input{type: "text", placeholder: "例) 柳ビル103", class: "chapter-container__form__group__answer"}
+            %button.chapter-container__form__button{type: "submit"} 
+              変更する
+            .chapter-container__form__rights
+              本人情報の登録について
+              = icon 'fas', 'angle-right'
+              = link_to ""
+
+= render 'banner'  # 全体のバナーの部分テンプレートの呼び出し
+
+= render 'footer'  # 全体のフッターの部分テンプレートの呼び出し
+
+= render 'camera_icon'  # 右下に出るカメラアイコンの部分テンプレートの呼び出し
+

--- a/app/views/products/user_profile_information.html.haml
+++ b/app/views/products/user_profile_information.html.haml
@@ -40,8 +40,6 @@
               .chapter-container__form__group__any
                 任意
               %input{type: "text", placeholder: "例)1234567", class: "chapter-container__form__group__answer"}
-
-
             .chapter-container__form__group
               .chapter-container__form__group__question
                 都道府県
@@ -50,13 +48,6 @@
               = form_with model: @product, class: "chapter-container__form__group__wrap", local: true do |f|
                 = icon 'fa', 'chevron-down', class: "chapter-container__form__group__wrap__icon"
                 = f.collection_select :prefecture_id, Prefecture.all, :id, :name,{}, {class: "chapter-container__form__group__wrap__select"}
-                
-
-
-
-
-
-
             .chapter-container__form__group
               .chapter-container__form__group__question
                 市区町村  


### PR DESCRIPTION
# what
マイページの本人情報の追加登録ページの実装。
# why
ウィザード形式でも登録できるが、本人情報の追加登録ページからでも登録できるようにするため。

確認画面のgyazoです。↓
https://gyazo.com/39d48ac5ab1434404760748601fce84d