### PR TITLE
登録画面のSNSビューの変更

### DIFF
--- a/app/assets/stylesheets/create_credit_card.scss
+++ b/app/assets/stylesheets/create_credit_card.scss
@@ -39,6 +39,7 @@
         
       }
       &__facebook{
+        text-align: center;
         position: relative;
         display: block;
         width: 100%;
@@ -58,6 +59,7 @@
         }
       }
       &__google{
+        text-align: center;
         position: relative;
         display: block;
         width: 100%;


### PR DESCRIPTION
＃What
ビューの修正

＃Why
ボタンないの文字列が左によっていたので